### PR TITLE
Testbed

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,1 +1,4 @@
 ultrablue-server
+testbed/mkosi/
+testbed/mkosi.output/
+testbed/mkosi.extra/

--- a/server/dracut/90ultrablue/module-setup.sh
+++ b/server/dracut/90ultrablue/module-setup.sh
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2022 ANSSI
+# SPDX-License-Identifier: Apache-2.0
+#!/bin/bash
+
+# Prerequisite check(s) for module.
+check() {
+    # If the binary(s) requirements are not fulfilled the module can't be installed.
+    require_binaries ultrablue-server || return 1
+    return 0
+}
+
+# Module dependency requirements.
+depends() {
+    # This module has external dependency on other module(s).
+    echo bluetooth tpm2-tss
+    # Return 0 to include the dependent module(s) in the initramfs.
+    return 0
+}
+
+# Install the required file(s) and directories for the module in the initramfs.
+install() {
+    inst_multiple -o \
+        /usr/bin/ultrablue-server \
+        "${systemdsystemunitdir}"/ultrablue-server.service
+
+    $SYSTEMCTL -q --root "$initdir" enable ultrablue-server.service
+}

--- a/server/testbed/Makefile
+++ b/server/testbed/Makefile
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2022 ANSSI
+# SPDX-License-Identifier: Apache-2.0
+#
+hostbus := $(shell lsusb | grep Bluetooth | sed -r 's/([^0-9]*([0-9]*)){1}.*/\2/')
+hostaddr := $(shell lsusb | grep Bluetooth | sed -r 's/([^0-9]*([0-9]*)){2}.*/\2/')
+
+all: install scratch-build run
+quick: install cache-build run
+debug: install debug-build run
+
+scratch-build:
+	sudo mkosi -ff
+
+cache-build:
+	sudo mkosi --incremental -f
+
+debug-build:
+	sudo mkosi --kernel-command-line="systemd.log_level=debug systemd.log_target=console" --force
+
+install:
+	mkdir -p mkosi.extra/usr/lib/dracut/modules.d
+	cp -r ../dracut/90ultrablue mkosi.extra/usr/lib/dracut/modules.d/
+	mkdir -p mkosi.extra/usr/lib/systemd/system/
+	cp ../unit/ultrablue-server.service mkosi.extra/usr/lib/systemd/system/
+	cp ../unit/bluetooth.service mkosi.extra/usr/lib/systemd/system/
+	mkdir -p mkosi.extra/etc
+	cp ressources/crypttab mkosi.extra/crypttab
+
+run:
+	mkdir -p /tmp/emulated_tpm/ultrablue
+	
+	swtpm socket \
+	          --tpmstate dir=/tmp/emulated_tpm/ultrablue \
+	          --ctrl type=unixio,path=/tmp/emulated_tpm/ultrablue/swtpm-sock \
+	          --log level=20 --tpm2 --daemon
+	
+	sudo mkosi qemu \
+	    -chardev socket,id=chrtpm,path=/tmp/emulated_tpm/ultrablue/swtpm-sock \
+	    -tpmdev emulator,id=tpm0,chardev=chrtpm \
+	    -device tpm-tis,tpmdev=tpm0 \
+	    -usb -device usb-host,hostbus=${hostbus},hostaddr=${hostaddr}
+

--- a/server/testbed/mkosi.build
+++ b/server/testbed/mkosi.build
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2022 ANSSI
+# SPDX-License-Identifier: Apache-2.0
+
+#!/bin/bash
+
+set -e
+
+[ -z "${BUILDDIR}" ] && BUILDDIR=build
+
+mkdir -p "${DESTDIR}/usr/bin"
+go build -o "${DESTDIR}/usr/bin/ultrablue-server"

--- a/server/testbed/mkosi.default
+++ b/server/testbed/mkosi.default
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2022 ANSSI
+# SPDX-License-Identifier: Apache-2.0
+
+[Distribution]
+Distribution=arch
+
+[Output]
+Format=raw_btrfs
+Bootable=yes
+OutputDirectory=./mkosi.output
+Output=ultrablue.raw
+Encrypt=all
+WithUnifiedKernelImages=false
+SourceFileTransferFinal=copy-all
+
+[Validation]
+Password=root
+
+[Host]
+QemuHeadless=1
+
+[Partitions]
+RootSize=3G
+
+[Packages]
+WithNetwork=yes
+BuildPackages=
+        go
+        bluez
+        bluez-utils
+        tpm2-tools
+        tpm2-tss
+
+Packages=
+        gdb
+        vim
+        strace
+        qrencode
+        # TPM tools
+        tpm2-tools
+        tpm2-tss
+        cryptsetup
+        # bluetooth remote attestation tests
+        bluez
+        bluez-utils
+
+# Share caches with the top-level mkosi
+BuildDirectory=./mkosi/mkosi.builddir
+Cache=./mkosi/mkosi.cache
+
+BuildSources=../

--- a/server/testbed/mkosi.passphrase
+++ b/server/testbed/mkosi.passphrase
@@ -1,0 +1,1 @@
+passphrase

--- a/server/testbed/mkosi.postinst
+++ b/server/testbed/mkosi.postinst
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2022 ANSSI
+# SPDX-License-Identifier: Apache-2.0
+
+#!/bin/bash
+
+systemctl enable bluetooth.service

--- a/server/testbed/ressources/crypttab
+++ b/server/testbed/ressources/crypttab
@@ -1,0 +1,1 @@
+root /dev/sda2 - tpm2-device=auto,tpm2-pcrs=9

--- a/server/unit/bluetooth.service
+++ b/server/unit/bluetooth.service
@@ -1,0 +1,37 @@
+[Unit]
+Description=Bluetooth service
+Documentation=man:bluetoothd(8)
+ConditionPathIsDirectory=/sys/class/bluetooth
+
+[Service]
+Type=dbus
+BusName=org.bluez
+ExecStart=/usr/lib/bluetooth/bluetoothd
+NotifyAccess=main
+#WatchdogSec=10
+##Restart=on-failure
+#CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+LimitNPROC=1
+
+# Filesystem lockdown
+#ProtectHome=true
+#ProtectSystem=full
+#PrivateTmp=true
+#ProtectKernelTunables=true
+#ProtectControlGroups=true
+#ReadWritePaths=/var/lib/bluetooth
+#ReadOnlyPaths=/etc/bluetooth
+
+# Execute Mappings
+#MemoryDenyWriteExecute=true
+
+# Privilege escalation
+#NoNewPrivileges=true
+
+# Real-time
+RestrictRealtime=true
+
+[Install]
+WantedBy=bluetooth.target
+Alias=dbus-org.bluez.service
+

--- a/server/unit/ultrablue-server.service
+++ b/server/unit/ultrablue-server.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ultrablue remote attestation service
+After=bluetooth.service
+Wants=cryptsetup-pre.target
+Before=cryptsetup-pre.target
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ultrablue-server
+RemainAfterExit=yes
+TimeoutSec=60
+StandardOutput=tty
+
+[Install]
+WantedBy=bluetooth.target


### PR DESCRIPTION
This patchset adds an mkosi testbed to the project, note that the  rootfs is encrypted using the passphrase defined in the `mkosi.passphrase` file.