### PR TITLE
Testbed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,20 @@ The classical Ultrablue control flow consists of several steps:
 To enroll a phone as a verifier, start the server in enroll mode. This will display a QR code on the terminal. From the phone, run the client app, and tap the **+** icon on the top right corner to show a QR code scanner. On scan, an encrypted Bluetooth Low Energy channel will be established, and the enrollment will run automatically. Upon success, a device card will appear on the home page of the client application.
 
 ### 2. Initramfs configuration (optional)
-The following explains how to integrate Ultrablue in the boot process to guard disk encryption by a secret delivered by the phone.
+Once enrolled, you have to re-generate your initramfs in order to include the **ultrablue dracut module** in it,
+you hence have to install `server/dracut/90ultrablue` in the `/usr/lib/dracut/modules.d/` module directory. You can
+then run the following dracut command:
 
+```
+dracut --add ultrablue /path/to/initrd --force
+```
 
-// TODO
+That's it, you can pass to the attestation part.
 
 ### 3. Attestation
 If you did the initramfs configuration step, Ultrablue server will run automatically during the boot. Otherwise, manually start the server in attestation mode. Once started, the server will wait for a verifier (phone) to connect.
-
 
 From the phone, click on the **▶️** icon of the device card. This will run the attestation. When finished, the client application will display the attestation result.
 
 ---
 The Ultrablue project has been developped at ANSSI ([ssi.gouv.fr](http://ssi.gouv.fr)) by Loïc Buckwell, under the supervision of Nicolas Bouchinet and Gabriel Kerneis.
-
-

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,1 +1,4 @@
 ultrablue-server
+testbed/mkosi/
+testbed/mkosi.output/
+testbed/mkosi.extra/

--- a/server/dracut/90ultrablue/module-setup.sh
+++ b/server/dracut/90ultrablue/module-setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: 2022 ANSSI
+# SPDX-License-Identifier: Apache-2.0
+
+# Prerequisite check(s) for module.
+check() {
+    # If the binary(s) requirements are not fulfilled the module can't be installed.
+    require_binaries ultrablue-server || return 1
+    return 255
+}
+
+# Module dependency requirements.
+depends() {
+    # This module has external dependency on other module(s).
+    echo bluetooth tpm2-tss
+    # Return 0 to include the dependent module(s) in the initramfs.
+    return 0
+}
+
+# Install the required file(s) and directories for the module in the initramfs.
+install() {
+    inst_multiple -o \
+        /usr/bin/ultrablue-server \
+        "${systemdsystemunitdir}"/ultrablue-server.service
+
+    $SYSTEMCTL -q --root "$initdir" enable ultrablue-server.service
+}

--- a/server/testbed/Makefile
+++ b/server/testbed/Makefile
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2022 ANSSI
+# SPDX-License-Identifier: Apache-2.0
+#
+hostbus := $(shell lsusb | grep Bluetooth | sed -r 's/.*Bus ([0-9]+){1}.*/\1/')
+hostaddr := $(shell lsusb | grep Bluetooth | sed -r 's/.*Device ([0-9]+){1}.*/\1/')
+
+all: install scratch-build run
+quick: install cache-build run
+debug: install debug-build run
+
+scratch-build:
+	sudo mkosi -ff
+
+cache-build:
+	sudo mkosi --incremental -f
+
+debug-build:
+	sudo mkosi --kernel-command-line="systemd.log_level=debug systemd.log_target=console" --force
+
+install:
+	mkdir -p mkosi.extra/usr/lib/dracut/modules.d
+	cp -r ../dracut/90ultrablue mkosi.extra/usr/lib/dracut/modules.d/
+	mkdir -p mkosi.extra/usr/lib/systemd/system/
+	cp ../unit/ultrablue-server.service mkosi.extra/usr/lib/systemd/system/
+	mkdir -p mkosi.extra/etc
+	cp ressources/crypttab mkosi.extra/crypttab
+
+run:
+	mkdir -p /tmp/emulated_tpm/ultrablue
+	
+	swtpm socket \
+	          --tpmstate dir=/tmp/emulated_tpm/ultrablue \
+	          --ctrl type=unixio,path=/tmp/emulated_tpm/ultrablue/swtpm-sock \
+	          --log level=20 --tpm2 --daemon
+	
+	sudo mkosi qemu \
+	    -chardev socket,id=chrtpm,path=/tmp/emulated_tpm/ultrablue/swtpm-sock \
+	    -tpmdev emulator,id=tpm0,chardev=chrtpm \
+	    -device tpm-tis,tpmdev=tpm0 \
+	    -usb -device usb-host,hostbus=${hostbus},hostaddr=${hostaddr}
+

--- a/server/testbed/README.md
+++ b/server/testbed/README.md
@@ -1,0 +1,27 @@
+# Virtual testbed setup
+
+This testbed allows you to generate a linux distribution image (ie. archlinux, fedora, debian) with ultrablue server
+configured in it.
+
+Your machine needs `swtpm` installed and **bluetooth** devices.
+
+The virtual testbed generation is made by the `mkosi` tool you hence have to install it. A Makefile is available in
+order to generate the virtual testbed, feel free to appen a `--distribution <distroname>` option to the `mkosi`
+commands to specify the distribution you want to generate, which is by default the host one. Beware that `mkosi`
+needs root privileges in order to work and will write the `mkosi` and `mkosi.output` cache directories as root
+owned.
+
+## Testing ultrablue
+
+Once your distro image is generated, you can boot it using the `make run` command, then unlock the disk using the
+passphrase written in the `mkosi.passphrase` file.
+
+You can now enroll your `ultrablue client` using the `ultrablue --enroll` command. Once enrolled, you have to
+re-generate your initramfs in order to include the ultrablue dracut module in it, it can be done using the
+following dracut command:
+
+```
+dracut --add ultrablue /path/to/initrd --force
+```
+
+You can now reboot the testbed and use your `ultrablue client` once asked in order to attest your machine boot.

--- a/server/testbed/mkosi.build
+++ b/server/testbed/mkosi.build
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: 2022 ANSSI
+# SPDX-License-Identifier: Apache-2.0
+
+
+set -e
+
+[ -z "${BUILDDIR}" ] && BUILDDIR=build
+
+mkdir -p "${DESTDIR}/usr/bin"
+go build -o "${DESTDIR}/usr/bin/ultrablue-server"

--- a/server/testbed/mkosi.default.d/10-ultrablue.conf
+++ b/server/testbed/mkosi.default.d/10-ultrablue.conf
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2022 ANSSI
+# SPDX-License-Identifier: Apache-2.0
+
+[Output]
+Format=gpt_btrfs
+Bootable=yes
+OutputDirectory=./mkosi.output
+Output=ultrablue.raw
+Encrypt=all
+WithUnifiedKernelImages=false
+SourceFileTransferFinal=copy-all
+
+[Host]
+QemuHeadless=1
+
+[Partitions]
+RootSize=3G
+
+[Content]
+Password=
+Autologin=yes
+WithNetwork=yes
+
+# Share caches with the top-level mkosi
+BuildDirectory=./mkosi/mkosi.builddir
+Cache=./mkosi/mkosi.cache
+
+BuildSources=../

--- a/server/testbed/mkosi.default.d/arch/10-mkosi.arch
+++ b/server/testbed/mkosi.default.d/arch/10-mkosi.arch
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2022 ANSSI
+# SPDX-License-Identifier: Apache-2.0
+
+[Distribution]
+Distribution=arch
+
+[Packages]
+BuildPackages=
+	bluez
+	bluez-utils
+	go
+	tpm2-tools
+	tpm2-tss
+
+Packages=
+	bluez
+	bluez-utils
+	cryptsetup
+	gdb
+	qrencode
+	strace
+	tpm2-tools
+	tpm2-tss
+	vim

--- a/server/testbed/mkosi.default.d/debian/10-mkosi.debian
+++ b/server/testbed/mkosi.default.d/debian/10-mkosi.debian
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2022 ANSSI
+# SPDX-License-Identifier: Apache-2.0
+
+[Distribution]
+Distribution=debian
+Release=testing
+
+[Packages]
+BuildPackages=
+	bluez
+	bluez-tools
+	golang
+	libtss2-dev
+	tpm2-tools
+
+Packages=
+	bluez
+	bluez-tools
+	cryptsetup
+	gdb
+	libtss2-dev
+	qrencode
+	strace
+	tpm2-tools
+	vim

--- a/server/testbed/mkosi.default.d/fedora/10-mkosi.fedora
+++ b/server/testbed/mkosi.default.d/fedora/10-mkosi.fedora
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2022 ANSSI
+# SPDX-License-Identifier: Apache-2.0
+
+[Distribution]
+Distribution=fedora
+Release=36
+
+[Packages]
+BuildPackages=
+	bluez
+	bluez-tools
+	golang
+	tpm2-tools
+	tpm2-tss
+
+Packages=
+	bluez
+	bluez-tools
+	cryptsetup
+	gdb
+	qrencode
+	strace
+	tpm2-tools
+	tpm2-tss
+	vim

--- a/server/testbed/mkosi.default.d/opensuse/10-mkosi.opensuse
+++ b/server/testbed/mkosi.default.d/opensuse/10-mkosi.opensuse
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2022 ANSSI
+# SPDX-License-Identifier: Apache-2.0
+
+[Distribution]
+Distribution=opensuse
+Release=tumbleweed
+
+[Packages]
+BuildPackages=
+	bluez
+	bluez-tools
+	go
+	tpm2-tools
+	tpm2-tss
+
+Packages=
+	bluez
+	bluez-tools
+	cryptsetup
+	gdb
+	qrencode
+	strace
+	tpm2-tools
+	tpm2-tss
+	vim

--- a/server/testbed/mkosi.default.d/ubuntu/10-mkosi.ubuntu
+++ b/server/testbed/mkosi.default.d/ubuntu/10-mkosi.ubuntu
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2022 ANSSI
+# SPDX-License-Identifier: Apache-2.0
+
+[Distribution]
+Distribution=ubuntu
+Release=focal
+Repositories=main,universe
+
+[Packages]
+BuildPackages=
+	bluez
+	bluez-tools
+	golang
+	libtss2-dev
+	tpm2-tools
+
+Packages=
+	bluez
+	bluez-tools
+	cryptsetup
+	gdb
+	qrencode
+	strace
+	tpm2-tools
+	tpm2-tss
+	vim

--- a/server/testbed/mkosi.passphrase
+++ b/server/testbed/mkosi.passphrase
@@ -1,0 +1,1 @@
+passphrase

--- a/server/testbed/mkosi.postinst
+++ b/server/testbed/mkosi.postinst
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: 2022 ANSSI
+# SPDX-License-Identifier: Apache-2.0
+
+systemctl enable bluetooth.service

--- a/server/testbed/ressources/crypttab
+++ b/server/testbed/ressources/crypttab
@@ -1,0 +1,1 @@
+root /dev/sda2 - tpm2-device=auto,tpm2-pcrs=9

--- a/server/unit/ultrablue-server.service
+++ b/server/unit/ultrablue-server.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=ultrablue remote attestation service
+After=bluetooth.service
+Wants=cryptsetup-pre.target
+Before=cryptsetup-pre.target
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ultrablue-server
+TimeoutSec=60
+StandardOutput=tty
+
+[Install]
+WantedBy=bluetooth.target


### PR DESCRIPTION
Adds a test environment to the ultablue project, it's able to generate a linux distro image which includes the ultrablue server, its dracut module and systemd unit. Once the image is generated one can use it to enroll an ultrablue client and test a remote attested boot.