### PR TITLE
Encryption

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/sirupsen/logrus v1.5.0
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 )
 
 require (

--- a/server/go.mod
+++ b/server/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-ble/ble v0.0.0-20220207185428-60d1eecf2633
 	github.com/google/go-attestation v0.4.3
 	github.com/google/go-tpm v0.3.3
+	github.com/google/uuid v1.1.1
 	github.com/sirupsen/logrus v1.5.0
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 )

--- a/server/go.sum
+++ b/server/go.sum
@@ -186,6 +186,7 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/trillian v1.3.11/go.mod h1:0tPraVHrSDkA3BO6vKX67zgLXs6SsOAbHEivX+9mPgw=
 github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/server/go.sum
+++ b/server/go.sum
@@ -545,6 +545,7 @@ golang.org/x/sys v0.0.0-20210316092937-0b90fd5c4c48/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210629170331-7dc0b73dc9fb/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211204120058-94396e421777 h1:QAkhGVjOxMa+n4mlsAWeAU+BMZmimQAaNiMu+iUi94E=
 golang.org/x/sys v0.0.0-20211204120058-94396e421777/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/server/main.go
+++ b/server/main.go
@@ -92,7 +92,7 @@ func main() {
 
 	if *enroll {
 		logrus.Info("Generating symmetric key")
-		if enrollkey, err = getTPMRandom(32); err != nil {
+		if enrollkey, err = TPM2_GetRandom(32); err != nil {
 			logrus.Fatal(err)
 		}
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -16,10 +16,11 @@ import (
 
 // Command line arguments - Global variables
 var (
-	enroll       = flag.Bool("enroll", false, "Must be true for a first time attestation")
+	enroll       = flag.Bool("enroll", false, "Must be set for a first time attestation (known as the enrollment)")
 	loglevel     = flag.Int("loglevel", 1, "Indicates the level of logging, 0 is the minimum, 3 is the maximum")
 	mtu          = flag.Int("mtu", 500, "Set a custom MTU, which is basically the max size of the BLE packets")
 	pcrextend    = flag.Bool("pcr-extend", false, "Extend the 9th PCR with the verifier secret on attestation success")
+	withpin      = flag.Bool("with-pin", false, "Use a PIN to seal the encryption key to the TPM (default is sealing to the SRK without password)")
 )
 
 // Encryption key used at enroll time. It needs to be globally available

--- a/server/main.go
+++ b/server/main.go
@@ -61,7 +61,7 @@ func initLogger(loglevel int) {
 	the server exposes characteristics and it is up to the client to read or
 	write them whenever it wants.
 
-	Ultrablue implements an inversion of control through serveral components,
+	Ultrablue implements an inversion of control through several components,
 	abstracting the BLE layer and allowing the server to drive the exchange.
 	Each of those components, briefly described here, is implemented in a
 	dedicated file named after the functionality.

--- a/server/protocol.go
+++ b/server/protocol.go
@@ -83,10 +83,16 @@ func establishEncryptedSession(ch chan []byte) (*Session, error) {
 	if *enroll {
 		key = enrollkey
 		enrollkey = nil
+		logrus.Info("Saving UUID & encryption key")
+		err = storeKey(session.uuid.String(), key)
+	} else {
+		logrus.Info("Fetching encryption key")
+		key, err = loadKey(session.uuid.String())
 	}
-	// NOTE: The key will be null during an attestation, because
-	// key persistence isn't yet implemented. Only the enrollment
-	// works as expected for now.
+	if err != nil {
+		close(ch)
+		return nil, err
+	}
 	if err := session.StartEncryption(key); err != nil {
 		close(ch)
 		return nil, err

--- a/server/session.go
+++ b/server/session.go
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2023 ANSSI
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"errors"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+)
+
+/*
+	The Session type is an abstraction on top of the Go channel used to pass
+	binary data to the goroutine reading and writing on the BLE characteristic.
+	It takes care of automatically encoding and encrypting Go objects before
+	sending them on the channel, and the other way around for received messages.
+*/
+type Session struct {
+	ch chan []byte
+	aesgcm cipher.AEAD
+	encrypted bool
+	uuid uuid.UUID
+}
+
+/*
+	Creates and returns a new Session for the given channel
+*/
+func NewSession(ch chan []byte) *Session {
+	return &Session {
+		ch: ch,
+	}
+}
+
+/*
+	Creates an AES/GCM cipher from the given key and stores it
+	in the Session. Also marks it as encrypted, so that
+	subsequent calls to sendMsg/recvMsg with this Session will
+	be encrypted.
+*/
+func (s *Session) StartEncryption(key []byte) error {
+	if s.encrypted {
+		return errors.New("The session is already encrypted")
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return err
+	}
+	if s.aesgcm, err = cipher.NewGCM(block); err != nil {
+		return err
+	}
+	s.encrypted = true
+	return nil
+}
+
+/*
+	sendMsg takes the data to send, which is a generic,
+	and sends it to the message channel (through the session)
+	of the connection state, encoded to CBOR.
+	This will make the message available to read
+	on the characteristic, and the function will
+	block until the client reads it completely.
+
+	If an error arises, and the channel is still open,
+	sendMsg closes it.
+*/
+func sendMsg[T any](obj T, session *Session) error {
+	logrus.Debug("Encoding to CBOR")
+	data, err := cbor.Marshal(obj)
+	if err != nil {
+		close(session.ch)
+		return err
+	}
+	if session.encrypted {
+		logrus.Debug("Encrypting (AES/GCM)")
+		iv, err := TPM2_GetRandom(uint16(session.aesgcm.NonceSize()))
+		if err != nil {
+			close(session.ch)
+			return err
+		}
+		data = session.aesgcm.Seal(iv, iv, data, nil) // Append encrypted data to the IV
+	}
+	logrus.Debug("Sending message")
+	session.ch <- data
+	_, ok := <-session.ch
+	if !ok {
+		return errors.New("The channel has been closed")
+	}
+	return nil
+}
+
+/*
+	recvMsg blocks until a message has been fully
+	written by the client on the characteristic.
+	It then tries to decode the CBOR message, and
+	stores it in the obj parameter. Since obj is declared
+	beforehand, and has a strong type, the cbor package
+	will be able to decode it.
+
+	If an error arises, and the channel is still open,
+	recvMsg closes it.
+*/
+func recvMsg[T any](obj *T, session *Session) error {
+	var err error
+
+	logrus.Debug("Receiving message")
+	data, ok := <-session.ch
+	if !ok {
+		return errors.New("The channel has been closed")
+	}
+	if session.encrypted {
+		logrus.Debug("Decrypting (AES/GCM)")
+		nonceSize := session.aesgcm.NonceSize()
+		if len(data) < nonceSize {
+			return errors.New("Data not large enough to be prefixed with the IV. Must be at least 12 bytes")
+		}
+		if data, err = session.aesgcm.Open(nil, data[:nonceSize], data[nonceSize:], nil); err != nil {
+			close(session.ch)
+			return err
+		}
+	}
+	logrus.Debug("Decoding from CBOR")
+	if err = cbor.Unmarshal(data, obj); err != nil {
+		close(session.ch)
+		return err
+	}
+	return nil
+}

--- a/server/tpm2.go
+++ b/server/tpm2.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2022 ANSSI
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpmutil"
+)
+
+/*
+   Returns @size bytes of random data from the TPM
+*/
+func TPM2_GetRandom(size uint16) ([]byte, error) {
+	rwc, err := tpm2.OpenTPM()
+	if err != nil {
+		return nil, err
+	}
+	defer rwc.Close()
+
+	rbytes, err := tpm2.GetRandom(rwc, size)
+	if err != nil {
+		return nil, err
+	}
+	return rbytes, nil
+}
+
+/*
+	Extends the PCR at the given index with @secret
+	TODO: The following extends the PCR, but does not adds
+	any event log entry. This is sufficient for our needs,
+	but it means that after an ultrablue attestation, the
+	eventlog will differ from the pcrs, thus making any
+	replay fail.
+	NOTE: It seems that it's not possible to add an event log
+	entry directly from the tss stack, and that we need to use
+	exposed UEFI function pointers.
+*/
+func TPM2_PCRExtend(index int, secret []byte) error {
+	rwc, err := tpm2.OpenTPM()
+	if err != nil {
+		return err
+	}
+	defer rwc.Close()
+
+	return tpm2.PCREvent(rwc, tpmutil.Handle(index), secret)
+}

--- a/server/tpm2.go
+++ b/server/tpm2.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -177,6 +178,9 @@ func TPM2_GetRandom(size uint16) ([]byte, error) {
 	rbytes, err := tpm2.GetRandom(rwc, size)
 	if err != nil {
 		return nil, err
+	}
+	if rbytes == nil || len(rbytes) != int(size) || onlyContainsZeros(rbytes) {
+		return nil, errors.New("Failed to generate random bytes")
 	}
 	return rbytes, nil
 }

--- a/server/tpm2.go
+++ b/server/tpm2.go
@@ -4,9 +4,134 @@
 package main
 
 import (
+	"io"
+
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
+	"github.com/sirupsen/logrus"
 )
+
+// TCG TPM v2.0 Provisioning Guidance, section 7.8:
+// https://trustedcomputinggroup.org/wp-content/uploads/TCG-TPM-v2.0-Provisioning-Guidance-Published-v1r1.pdf
+const SRK_HANDLE tpmutil.Handle = 0x81000001
+
+// TCG TPM v2.0 Provisioning Guidance, section 7.5.1:
+// https://trustedcomputinggroup.org/wp-content/uploads/TCG-TPM-v2.0-Provisioning-Guidance-Published-v1r1.pdf
+// TCG EK Credential Profile, section 2.1.5.1:
+// https://trustedcomputinggroup.org/wp-content/uploads/Credential_Profile_EK_V2.0_R14_published.pdf
+var SRK_TEMPLATE = tpm2.Public {
+	Type: tpm2.AlgRSA,
+	NameAlg: tpm2.AlgSHA256,
+	Attributes: tpm2.FlagFixedTPM | tpm2.FlagFixedParent | tpm2.FlagSensitiveDataOrigin | tpm2.FlagUserWithAuth | tpm2.FlagRestricted | tpm2.FlagDecrypt | tpm2.FlagNoDA,
+	AuthPolicy: nil,
+	RSAParameters: &tpm2.RSAParams {
+		Symmetric: &tpm2.SymScheme {
+			Alg: tpm2.AlgAES,
+			KeyBits: 128,
+			Mode: tpm2.AlgCFB,
+		},
+		KeyBits: 2048,
+		ModulusRaw: make([]byte, 256),
+	},
+}
+
+/*
+	Returns a handle to the TPM Storage Rook Key (SRK) if it's already present
+	in its non volatile memory.
+	Otherwise, a new SRK is created using the default template, and is persisted
+	in the TPM Non Volatile memory, at its default location. A handle to the newly
+	created key is then returned
+*/
+func TPM2_LoadSRK(rwc io.ReadWriteCloser) (tpmutil.Handle, error) {
+	// TPM2 Library commands, section 30.2:
+	// https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_pub.pdf
+	// "TPM_CAP_HANDLES – Returns a list of all of the handles within the handle range
+	// of the property parameter. The range of the returned handles is determined
+	// by the handle type (the most-significant octet (MSO) of the property)."
+	const PROPERTY = uint32(tpm2.HandleTypePersistent) << 24
+	const MAX_OBJECTS = 256
+
+	handles, _, err := tpm2.GetCapability(rwc, tpm2.CapabilityHandles, MAX_OBJECTS, PROPERTY)
+	if err != nil {
+		return 0, nil
+	}
+	for _, h := range handles {
+		if h.(tpmutil.Handle) == SRK_HANDLE {
+			return SRK_HANDLE, nil
+		}
+	}
+	logrus.Info("SRK not found, creating one. This may take a while.")
+
+	handle, _, err := tpm2.CreatePrimary(rwc, tpm2.HandleOwner, tpm2.PCRSelection{}, "", "", SRK_TEMPLATE)
+	if err != nil {
+		return 0, err
+	}
+	if err = tpm2.EvictControl(rwc, "", tpm2.HandleOwner, handle, SRK_HANDLE); err != nil {
+		return 0, err
+	}
+	logrus.Infof("Persistent SRK created at NV index %x\n", SRK_HANDLE)
+	return SRK_HANDLE, nil
+}
+
+/*
+	Seals the given data to the TPM Storage Root Key (SRK) and
+	returns the resulting private and public blobs
+*/
+func TPM2_Seal(data []byte) ([]byte, []byte, error) {
+	var rwc io.ReadWriteCloser
+	var priv, pub, policy []byte
+	var srkHandle, sessHandle tpmutil.Handle
+	var err error
+
+	if rwc, err = tpm2.OpenTPM(); err != nil {
+		return nil, nil, err
+	}
+	defer rwc.Close()
+
+	if srkHandle, err = TPM2_LoadSRK(rwc); err != nil {
+		return nil, nil, err
+	}
+	if sessHandle, _, err = tpm2.StartAuthSession(rwc, tpm2.HandleNull, tpm2.HandleNull, make([]byte, 16), nil, tpm2.SessionPolicy, tpm2.AlgNull, tpm2.AlgSHA256); err != nil {
+		return nil, nil, err
+	}
+	if policy, err = tpm2.PolicyGetDigest(rwc, sessHandle); err != nil {
+		return nil, nil, err
+	}
+	if priv, pub, err = tpm2.Seal(rwc, srkHandle, "", "", policy, data); err != nil {
+		return nil, nil, err
+	}
+	return priv, pub, err
+}
+
+/*
+	Unseals the given object with the TPM Storage Root Key (SRK)
+	and returns the original data
+*/
+func TPM2_Unseal(priv, pub []byte) ([]byte, error) {
+	var rwc io.ReadWriteCloser
+	var data []byte
+	var srkHandle, keyHandle, sessHandle tpmutil.Handle
+	var err error
+
+	if rwc, err = tpm2.OpenTPM(); err != nil {
+		return nil, err
+	}
+	defer rwc.Close()
+
+	if srkHandle, err = TPM2_LoadSRK(rwc); err != nil {
+		return nil, err
+	}
+	if sessHandle, _, err = tpm2.StartAuthSession(rwc, tpm2.HandleNull, tpm2.HandleNull, make([]byte, 16), nil, tpm2.SessionPolicy, tpm2.AlgNull, tpm2.AlgSHA256); err != nil {
+		return nil, err
+	}
+	if keyHandle, _, err = tpm2.Load(rwc, srkHandle, "", pub, priv); err != nil {
+		return nil, err
+	}
+	if data, err = tpm2.UnsealWithSession(rwc, sessHandle, keyHandle, ""); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
 
 /*
    Returns @size bytes of random data from the TPM

--- a/server/utils.go
+++ b/server/utils.go
@@ -4,50 +4,8 @@
 package main
 
 import (
-	"github.com/google/go-tpm/tpm2"
-	"github.com/google/go-tpm/tpmutil"
 	"github.com/skip2/go-qrcode"
 )
-
-/*
-   getTPMRandom gets @size random bytes from the TPM.
-   This function is used to generate AES keys and IVs.
-*/
-func getTPMRandom(size uint16) ([]byte, error) {
-	rwc, err := tpm2.OpenTPM()
-	if err != nil {
-		return nil, err
-	}
-	defer rwc.Close()
-
-	rbytes, err := tpm2.GetRandom(rwc, size)
-	if err != nil {
-		return nil, err
-	}
-	return rbytes, nil
-}
-
-func extendPCR(index int, secret []byte) error {
-	rwc, err := tpm2.OpenTPM()
-	if err != nil {
-		return err
-	}
-	defer rwc.Close()
-
-	// TODO: The following extends the PCR, but does not adds
-	// any event log entry. This is sufficient for our needs,
-	// but it means that after an ultrablue attestation, the
-	// eventlog will differ from the pcrs, thus making any
-	// replay fail.
-	// NOTE: It seems that it's not possible to add an event log
-	// entry directly from the tss stack, and that we need to use
-	// exposed UEFI function pointers.
-	err = tpm2.PCREvent(rwc, tpmutil.Handle(index), secret)
-	if err != nil {
-		return err
-	}
-	return nil
-}
 
 /*
 	generateQRCode generates a QR code containing the

--- a/server/utils.go
+++ b/server/utils.go
@@ -4,8 +4,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 	"github.com/skip2/go-qrcode"
@@ -57,9 +55,9 @@ func extendPCR(index int, secret []byte) error {
 	ascii art string.
 */
 func generateQRCode(data string) (string, error) {
-	qr, err := qrcode.New(fmt.Sprintf("%s\n", data), qrcode.Low)
+	qr, err := qrcode.New(data, qrcode.Low)
 	if err != nil {
 		return "", err
 	}
-	return qr.ToString(false), nil
+	return qr.ToSmallString(false), nil
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -93,3 +93,15 @@ func generateQRCode(data string) (string, error) {
 	}
 	return qr.ToSmallString(false), nil
 }
+
+/*
+	Returns true if the data only contains zeros, false otherwise
+*/
+func onlyContainsZeros(data []byte) bool {
+	for _, b := range data {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Implements encryption/decryption on server-side, using AES256/GCM:

- At enroll time, the server now generates a 256bits symmetric key, which is added to the QRcode. On connection, the new attester generates a UUID and sends it to the server. The server then seals the symmetric key to the TPM Storage Root Key (SRK), and stores the resulting blobs in two files: `/etc/ultrablue/UUID` and `/etc/ultrablue/UUID.pub`.

- During a classic attestation, the client sends the UUID it previously stored, and the server will retrieve and unseal the corresponding key.

In both cases, the first message is the client UUID, and every message after this one are encrypted.

A random IV is generated for each message, and the data send to the characteristic channel actually looks like this:
```
[size][IV][Ciphertext [CBOR [Plaintext]]]
0    4   16                           16 + size
```

This pull request also contains minor changes:
- TPM related functions are moved out from `utils.go` to `tpm.go`
- The `RegistrationData` structure has been renamed to `EnrollData`
- Adds/Updates some comments