### PR TITLE
[server] Authentication nonce tweak

### DIFF
--- a/server/protocol.go
+++ b/server/protocol.go
@@ -144,7 +144,14 @@ func authentication(session *Session) error {
 		return err
 	}
 	logrus.Info("Verifying nonce")
-	if bytes.Equal(nonce.Bytes, rcvd_nonce.Bytes) == false {
+	if len(rcvd_nonce.Bytes) != 16 {
+		close(session.ch)
+		return errors.New("Authentication failure: Invalid nonce")
+	}
+	// We choosed the following tweak because it's easy to implement for most
+	// languages, and makes every bit change.
+	tweaked_nonce := append(rcvd_nonce.Bytes[8:], rcvd_nonce.Bytes[:8]...)
+	if bytes.Equal(nonce.Bytes, tweaked_nonce) == false {
 		close(session.ch)
 		return errors.New("Authentication failure: nonces differ")
 	}

--- a/server/protocol_test.go
+++ b/server/protocol_test.go
@@ -4,10 +4,13 @@
 package main
 
 import (
+	"crypto/rand"
 	"reflect"
 	"testing"
 
 	"github.com/fxamacker/cbor/v2"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 func TestSendMsg_NormalCase(t *testing.T) {
@@ -20,7 +23,7 @@ func TestSendMsg_NormalCase(t *testing.T) {
 	go func(ch chan []byte, t *testing.T) {
 		_, ok := <-ch
 		if !ok {
-			t.Fatal("The channel has been closed")
+			t.Error("The channel has been closed")
 		}
 		ch <- nil
 	}(session.ch, t)
@@ -43,7 +46,7 @@ func TestSendMsg_WithError(t *testing.T) {
 	go func(ch chan []byte, t *testing.T) {
 		_, ok := <-ch
 		if !ok {
-			t.Fatal("The channel has been closed")
+			t.Error("The channel has been closed")
 		}
 		close(ch) // This means an error occured
 	}(session.ch, t)
@@ -54,29 +57,6 @@ func TestSendMsg_WithError(t *testing.T) {
 		t.Error("sendMsg succeeded whereas the channel closed unexpectedly")
 	}
 }
-
-/*
-	// I'm sad to admit it, but I can't manage to make the cbor.Marshal function fail...
-	func TestSendMsg_EncodingFailure(t *testing.T) {
-		var data = []int {4, 8, 15, 16, 23, 42}
-		var ch = make(chan []byte)
-
-		// Emulate a client read on the characteristic
-		go func(ch chan []byte, t *testing.T) {
-			_, ok := <- ch
-			if !ok {
-				t.Fatal("The channel has been closed")
-			}
-			ch <- nil
-		}(ch , t)
-
-		// Make sure an error occured
-		err := sendMsg(data, ch)
-		if err == nil {
-			t.Error("sendMsg succeeded whereas the channel closed unexpectedly")
-		}
-	}
-*/
 
 func TestRecvMsg_NormalCase(t *testing.T) {
 	var data []int
@@ -90,7 +70,7 @@ func TestRecvMsg_NormalCase(t *testing.T) {
 		var data = []int{4, 8, 15, 16, 23, 42}
 		var encoded, err = cbor.Marshal(data)
 		if err != nil {
-			t.Fatalf("Failed to encode %#v as CBOR", data)
+			t.Errorf("Failed to encode %#v as CBOR", data)
 		}
 		ch <- encoded
 	}(session.ch, t)
@@ -142,5 +122,124 @@ func TestRecvMsg_InvalidCBOR(t *testing.T) {
 	err := recvMsg(&data, session)
 	if err == nil {
 		t.Error("recvMsg succeeded whereas invalid CBOR data was sent")
+	}
+}
+
+func FakeCharacteristicRecv[T any](obj *T, session *Session) error {
+	err := recvMsg(obj, session)
+	if err != nil {
+		return err
+	}
+	session.ch <- nil
+	return nil
+}
+
+func FakeCharacteristicSend[T any](obj T, session *Session) error {
+	err := sendMsg(obj, session)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func FakeCharacteristicRecvRaw(data []byte, session *Session) error {
+	data, ok := <-session.ch
+	if !ok {
+		return errors.New("The channel has been closed")
+	}
+	session.ch <- nil
+	return nil
+}
+
+func FakeCharacteristicSendRaw(data []byte, session *Session) error {
+	session.ch <- data
+	_, ok := <-session.ch
+	if !ok {
+		return errors.New("The channel has been closed")
+	}
+	return nil
+}
+
+func TestAuthentication_ValidNonce(t *testing.T) {
+	logrus.SetLevel(0)
+	var key = make([]byte, 32)
+	var session = &Session {
+		ch: make(chan []byte),
+	}
+	_, err := rand.Read(key)
+	if err != nil {
+		t.Error("Failed to generate random")
+	}
+	session.StartEncryption(key)
+
+	// Emulate a genuine client
+	go func(s *Session, t *testing.T) {
+		var auth_nonce Bytestring
+		err := FakeCharacteristicRecv(&auth_nonce, session)
+		if err != nil {
+			t.Error("Error while receiving auth nonce")
+		}
+		tweaked_nonce := Bytestring {
+			Bytes: append(auth_nonce.Bytes[8:], auth_nonce.Bytes[:8]...),
+		}
+		if err = FakeCharacteristicSend(tweaked_nonce, session); err != nil {
+			t.Error("Error while sending tweaked nonce")
+		}
+	}(session, t)
+
+	if err := authentication(session); err != nil {
+		t.Error("Unexpected error during authentication:", err)
+	}
+}
+
+func TestAuthentication_UntweakedNonce(t *testing.T) {
+	logrus.SetLevel(0)
+	var key = make([]byte, 32)
+	var session = &Session {
+		ch: make(chan []byte),
+	}
+	_, err := rand.Read(key)
+	if err != nil {
+		t.Error("Failed to generate random")
+	}
+	session.StartEncryption(key)
+
+	// Emulate a client that doesn't tweaks the nonce
+	go func(s *Session, t *testing.T) {
+		var auth_nonce Bytestring
+		err := FakeCharacteristicRecv(&auth_nonce, session)
+		if err != nil {
+			t.Error("Error while receiving auth nonce")
+		}
+		auth_nonce = Bytestring {
+			Bytes: make([]byte, 16),
+		}
+		FakeCharacteristicSend(auth_nonce, session)
+	}(session, t)
+
+	if err = authentication(session); err == nil {
+		t.Error("An error should have occured, because the teak hasn't been applied", err)
+	}
+}
+
+func TestAuthentication_ReplayedNonce(t *testing.T) {
+	logrus.SetLevel(0)
+	var session = &Session {
+		ch: make(chan []byte),
+	}
+
+	// Emulate a client who doesn't have the symmetric key and attempts to resend
+	// the unmodified reveived nonce
+	go func(s *Session, t *testing.T) {
+		var auth_nonce Bytestring
+		err := FakeCharacteristicRecvRaw(auth_nonce.Bytes, session)
+		if err != nil {
+			t.Error("Error while receiving auth nonce")
+		}
+		FakeCharacteristicSendRaw(auth_nonce.Bytes, session)
+	}(session, t)
+
+	if err := authentication(session); err == nil {
+		t.Error("An error should have occured, because the teak hasn't been applied", err)
 	}
 }


### PR DESCRIPTION
Fix a potential authentication bypass:

During the authentication phase, we send an encrypted nonce, with a prepended IV, needed by the client to decrypt the nonce with the shared key. The client then have to reencrypt the nonce with another IV and send it back to the server.
The server then compares the received nonce with the sent one and if they match, the client is authenticated.

The issue here is that an attacker can connect, listen for the encrypted nonce from the server, and send back the exact same message. This message contains the right nonce, encrypted with the shared key and a valid IV.

Tweaking the nonce in a deterministic way before sending it back ensures that someone who doesn't know the shared key can't successfully bypass the authentication process.

The way we tweak the nonce is the following:

- We split the nonce in two halfs (8 bytes long each)
- We invert those halfs

In python, it would give: tweaked_nonce = nonce[8:] + nonce[:8]

Signed-off-by: Loic Buckwell <lfalkau@student.42.fr>